### PR TITLE
Fixed casing of the GitHub logo

### DIFF
--- a/_data/sponsors.yaml
+++ b/_data/sponsors.yaml
@@ -3,7 +3,7 @@
   logo: /images/xebia.png
 - name: GitHub
   url: https://github.com
-  logo: /images/GitHub_Logo_white.png
+  logo: /images/GitHub_Logo_White.png
 - name: Microsoft
   url: https://microsoft.com
   logo: /images/microsoft-logo-black-and-white.png


### PR DESCRIPTION
The GitHub logo is currently not loading on the site

![CleanShot 2024-03-17 at 06 48 18](https://github.com/globaldevopsexperience/event-portal/assets/5680199/8d12ff5d-1920-460d-8aef-da027fd10932)

![CleanShot 2024-03-17 at 06 48 48](https://github.com/globaldevopsexperience/event-portal/assets/5680199/6eb218fb-a696-49ff-a8d6-e33706cdf206)
**Figure: Image currently going to `GitHub_Logo_white.png`**

![CleanShot 2024-03-17 at 06 49 36](https://github.com/globaldevopsexperience/event-portal/assets/5680199/6c486a9c-bd0e-47d1-96aa-01906ea86004)
**Figure: Image loads fine with a capital W on `GitHub_Logo_White.png`**